### PR TITLE
Users collector plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+.idea
+tmp/
+*.tmp
+scratch/
+build/
+*.swp
+profile.cov
+gin-bin
+
+# we don't vendor godep _workspace
+**/Godeps/_workspace/**
+
+# OSX stuff
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: required
+language: go
+go:
+- 1.5
+env:
+  global:
+    - SNAP_PLUGIN_SOURCE=/home/travis/gopath/src/github.com/intelsdi-x/snap-plugin-collector-users
+  matrix:
+    - TEST=unit
+before_install:
+- go get github.com/tools/godep
+- go get github.com/intelsdi-x/snap
+- if [ ! -d $SNAP_PLUGIN_SOURCE ]; then mkdir -p $HOME/gopath/src/github.com/intelsdi-x; ln -s $TRAVIS_BUILD_DIR $SNAP_PLUGIN_SOURCE; fi # CI for forks not from intelsdi-x
+install:
+- export TMPDIR=$HOME/tmp
+- mkdir -p $TMPDIR
+- cd $SNAP_PLUGIN_SOURCE # change dir into source
+- make deps
+script:
+- make check TEST=$TEST 2>&1 # Run test suite
+notifications:
+  slack:
+    secure: VkbZLIc2RH8yf3PtIAxUNPdAu3rQQ7yQx0GcK124JhbEnZGaHyK615V0rbG7HcVmYKGPdB0cXqZiLBDKGqGKb2zR1NepOe1nF03jxGSpPq8jIFeEXSJGEYGL34ScDzZZGuG6qwbjFcXiW5lqn6t8igzp7v2+URYBaZo5ktCS2xY=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# snap collector plugin - users
+
+1. [Contributing Code](#contributing-code)
+2. [Contributing Examples](#contributing-examples)
+3. [Contribute Elsewhere](#contribute-elsewhere)
+4. [Thank You](#thank-you)
+
+
+This repository is primarily **community supported**. We both appreciate and need your contribution to keep it stable.
+Thank you for being part of the community! We love you for it.
+
+## Contributing Code
+**_IMPORTANT_**: We encourage contributions to the project from the community. We ask that you keep the following guidelines in mind when planning your contribution.
+
+* Whether your contribution is for a bug fix or a feature request, **create an [Issue](https://github.com/intelsdi-x/snap-plugin-collector-users/issues)** and let us know what you are thinking
+* **For bugs**, if you have already found a fix, feel free to submit a Pull Request referencing the Issue you created
+* **For feature requests**, we want to improve upon the library incrementally which means small changes at a time. In order ensure your PR can be reviewed in a timely manner, please keep PRs small, e.g. <10 files and <500 lines changed. If you think this is unrealistic, then mention that within the issue and we can discuss it
+
+Once you're ready to contribute code back to this repo, start with these steps:
+
+* Fork the appropriate sub-projects that are affected by your change
+* Clone the fork to `$GOPATH/src/github.com/intelsdi-x/`
+	```
+	$ git clone https://github.com/<yourGithubID>/<project>.git
+	```
+* Create a topic branch for your change and checkout that branch  
+    ```
+    $ git checkout -b some-topic-branch
+    ```
+* Make your changes and run the test suite if one is provided (see below)
+* Commit your changes and push them to your fork
+* Open a pull request for the appropriate project
+* Contributors will review your pull request, suggest changes, and merge it when it’s ready and/or offer feedback
+* To report a bug or issue, please open a new issue against this repository
+
+If you have questions feel free to contact the [maintainers](https://github.com/intelsdi-x/snap/blob/master/README.md#maintainers).
+
+## Contributing Examples
+The most immediately helpful way you can benefit this project is by cloning the repository, adding some further examples and submitting a pull request.
+
+Have you written a blog post about how you use [snap](http://github.com/intelsdi-x/snap) and/or this plugin? Send it to us!
+
+
+## Contribute Elsewhere
+This repository is one of **many** plugins in **snap**, a powerful telemetry framework. See the full project at http://github.com/intelsdi-x/snap
+
+## Thank You
+And **thank you!** Your contribution, through code and participation, is incredibly important to us.

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,6 @@
+{
+	"ImportPath": "github.com/intelsdi-x/snap-plugin-collector-users",
+	"GoVersion": "go1.5",
+	"Deps": [
+	]
+}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+default:
+	$(MAKE) deps
+	$(MAKE) all
+deps:
+	bash -c "godep restore"
+test:
+	bash -c "./scripts/test.sh $(TEST)"
+check:
+	$(MAKE) test
+all:
+	bash -c "./scripts/build.sh $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,192 @@
-# snap-plugin-collector-users
+# snap collector plugin - users
+
+This plugin has ability to gather the number of logged-in users. Though this type of information can be obtained from various files in the Linux system but in this plugin there is a command line utility 'who' to get the list of user logged in the system.
+															
+The plugin is used in the [snap framework] (http://github.com/intelsdi-x/snap).				
+
+1. [Getting Started](#getting-started)
+  * [System Requirements](#system-requirements)
+  * [Installation](#installation)
+  * [Configuration and Usage](#configuration-and-usage)
+2. [Documentation](#documentation)
+  * [Collected Metrics](#collected-metrics)
+  * [Examples](#examples)
+  * [Roadmap](#roadmap)
+3. [Community Support](#community-support)
+4. [Contributing](#contributing)
+5. [License](#license)
+6. [Acknowledgements](#acknowledgements)
+
+## Getting Started
+
+### System Requirements
+
+- Linux system
+
+### Installation
+
+#### To build the plugin binary:
+
+Fork https://github.com/intelsdi-x/snap-plugin-collector-users  
+Clone repo into `$GOPATH/src/github.com/intelsdi-x/`:
+
+```
+$ git clone https://github.com/<yourGithubID>/snap-plugin-collector-users.git
+```
+
+Build the snap users plugin by running make within the cloned repo:
+```
+$ make
+```
+This builds the plugin in `/build/rootfs/`
+
+### Configuration and Usage
+
+* Set up the [snap framework](https://github.com/intelsdi-x/snap/blob/master/README.md#getting-started)
+
+## Documentation
+
+### Collected Metrics
+This plugin has the ability to gather the following metrics:
+                                                                                                
+Metric namespace is `/intel/users/<metric name>/`
+
+Metric Name | Data Type | Description
+------------ | ------------- | -------------
+logged | uint64 | A number of users logged-in
+logged_min | uint64 | A minimum number of logged-in users<sup>(*)</sup>
+logged_max | uint64 | A maximum number of logged-in users<sup>(*)</sup>
+logged_avg | float64 | An average number of logged-in users<sup>(*)</sup>
+
+<sup>(*)</sup> since the task was started																																					
+By default metrics are gathered once per second.
+
+### Examples
+
+Example of running snap users collector and writing data to file.
+
+Run the snap daemon:
+```
+$ snapd -l 1 -t 0
+```
+
+Load users plugin for collecting:
+```
+$ snapctl plugin load $SNAP_USERS_PLUGIN_DIR/build/rootfs/snap-plugin-collector-users
+Plugin loaded
+Name: users
+Version: 1
+Type: collector
+Signed: false
+Loaded Time: Tue, 12 Jan 2016 05:25:35 EST
+```
+
+See available metrics:
+```
+$ snapctl metric list
+```
+
+Load file plugin for publishing:
+```
+$ snapctl plugin load $SNAP_DIR/build/plugin/snap-publisher-file
+Plugin loaded
+Name: file
+Version: 3
+Type: publisher
+Signed: false
+Loaded Time: Tue, 12 Jan 2016 05:26:21 EST
+```
+
+Create a task JSON file (exemplary file in examples/tasks/users-file.json):  
+```json
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/users/logged": {},
+                "/intel/users/logged_avg": {},
+                "/intel/users/logged_max": {},
+                "/intel/users/logged_min": {}
+            },
+            "config": {
+            },
+            "process": null,
+            "publish": [
+                {
+                    "plugin_name": "file",
+                    "config": {
+                        "file": "/tmp/published_users"
+                    }
+                }
+            ]
+        }
+    }
+}
+    
+```
+
+Create a task:
+```
+$ snapctl task create -t $SNAP_USERS_PLUGIN_DIR/examples/tasks/users-file.json
+Using task manifest to create task
+Task created
+ID: b0ba4a9c-9011-4117-bd25-803b732f8e5b
+Name: Task-b0ba4a9c-9011-4117-bd25-803b732f8e5b
+State: Running
+```
+See sample output from `snapctl task watch <task_id>`
+
+```
+$ snapctl task watch  b0ba4a9c-9011-4117-bd25-803b732f8e5b
+																								
+Watching Task (b0ba4a9c-9011-4117-bd25-803b732f8e5b):
+NAMESPACE                        DATA    TIMESTAMP                                       SOURCE
+/intel/users/logged              6       2016-01-12 05:33:43.275317916 -0500 EST         gklab-108-166
+/intel/users/logged_avg          5.48    2016-01-12 05:33:43.275317101 -0500 EST         gklab-108-166
+/intel/users/logged_max          6       2016-01-12 05:33:43.275317675 -0500 EST         gklab-108-166
+/intel/users/logged_min          5       2016-01-12 05:33:43.275317794 -0500 EST         gklab-108-166
+```
+(Keys `ctrl+c` terminate task watcher)
+
+
+These data are published to file and stored there (in this example in /tmp/published_users).
+
+Stop task:
+```
+$ snapctl task stop b0ba4a9c-9011-4117-bd25-803b732f8e5b
+Task stopped:
+ID: b0ba4a9c-9011-4117-bd25-803b732f8e5b
+```
+
+### Roadmap
+
+There isn't a current roadmap for this plugin, but it is in active development. As we launch this plugin, we do not have any outstanding requirements for the next release.
+
+If you have a feature request, please add it as an [issue](https://github.com/intelsdi-x/snap-plugin-collector-users/issues).
+
+## Community Support
+This repository is one of **many** plugins in the **Snap Framework**: a powerful telemetry agent framework. To reach out on other use cases, visit:
+
+* [Snap Gitter channel] (https://gitter.im/intelsdi-x/snap)
+
+The full project is at http://github.com:intelsdi-x/snap.
+
+## Contributing
+We love contributions!
+
+There's more than one way to give back, from examples to blogs to code updates. See our recommended process in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## License
+Snap, along with this plugin, is an Open Source software released under the Apache 2.0 [License](LICENSE).
+
+## Acknowledgements
+List authors, co-authors and anyone you'd like to mention
+
+* Author: 	[Izabella Raulin](https://github.com/IzabellaRaulin)
+
+**Thank you!** Your contribution is incredibly important to us.

--- a/examples/tasks/users-file.json
+++ b/examples/tasks/users-file.json
@@ -1,0 +1,28 @@
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/users/logged": {},
+                "/intel/users/logged_avg": {},
+                "/intel/users/logged_max": {},
+                "/intel/users/logged_min": {}                
+            },
+            "config": {
+            },
+            "process": null,
+            "publish": [
+                {
+                    "plugin_name": "file",
+                    "config": {
+                        "file": "/tmp/published_users"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,36 @@
+// +build linux
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright 2016 Intel Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	// Import the snap plugin library
+	"github.com/intelsdi-x/snap/control/plugin"
+
+	// Import our collector plugin implementation
+	"github.com/intelsdi-x/snap-plugin-collector-users/users"
+)
+
+func main() {
+
+	plugin.Start(
+		plugin.NewPluginMeta(users.Name, users.Version, users.Type, []string{}, []string{plugin.SnapGOBContentType}, plugin.ConcurrencyCount(1)),
+		users.New(),
+		os.Args[1],
+	)
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+GITVERSION=`git describe --always`
+SOURCEDIR=$1
+BUILDDIR=$SOURCEDIR/build
+PLUGIN=`echo $SOURCEDIR | grep -oh "snap-.*"`
+ROOTFS=$BUILDDIR/rootfs
+BUILDCMD='go build -a -ldflags "-w"'
+
+echo
+echo "****  Snap Plugin Build  ****"
+echo
+
+# Disable CGO for builds
+export CGO_ENABLED=0
+
+# Clean build bin dir
+rm -rf $ROOTFS/*
+
+# Make dir
+mkdir -p $ROOTFS
+
+# Build plugin
+echo "Source Dir = $SOURCEDIR"
+echo "Building Snap Plugin: $PLUGIN"
+$BUILDCMD -o $ROOTFS/$PLUGIN
+

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,85 @@
+#!/bin/bash -e
+# The script does automatic checking on a Go package and its sub-packages, including:
+# 1. gofmt         (http://golang.org/cmd/gofmt/)
+# 2. goimports     (https://github.com/bradfitz/goimports)
+# 3. golint        (https://github.com/golang/lint)
+# 4. go vet        (http://golang.org/cmd/vet)
+# 5. race detector (http://blog.golang.org/race-detector)
+# 6. test coverage (http://blog.golang.org/cover)
+
+# Capture what test we should run
+TEST_SUITE=$1
+
+if [[ $TEST_SUITE == "unit" ]]; then
+	go get github.com/axw/gocov/gocov
+	go get github.com/mattn/goveralls
+	go get -u github.com/golang/lint/golint
+	go get golang.org/x/tools/cmd/vet
+	go get golang.org/x/tools/cmd/goimports
+	go get github.com/smartystreets/goconvey/convey
+	go get github.com/stretchr/testify/mock
+	go get golang.org/x/tools/cmd/cover
+
+	COVERALLS_TOKEN=t47LG6BQsfLwb9WxB56hXUezvwpED6D11
+	TEST_DIRS="main.go users/"
+	VET_DIRS=". ./users/..."
+
+	set -e
+
+	# Automatic checks
+	echo "gofmt"
+	test -z "$(gofmt -l -d $TEST_DIRS | tee /dev/stderr)"
+
+	echo "goimports"
+	test -z "$(goimports -l -d $TEST_DIRS | tee /dev/stderr)"
+
+	# Useful but should not fail on link per: https://github.com/golang/lint
+	# "The suggestions made by golint are exactly that: suggestions. Golint is not perfect,
+	# and has both false positives and false negatives. Do not treat its output as a gold standard.
+	# We will not be adding pragmas or other knobs to suppress specific warnings, so do not expect
+	# or require code to be completely "lint-free". In short, this tool is not, and will never be,
+	# trustworthy enough for its suggestions to be enforced automatically, for example as part of
+	# a build process"
+	# echo "golint"
+	# golint ./...
+
+	echo "go vet"
+	go vet $VET_DIRS
+	# go test -race ./... - Lets disable for now
+
+	# Run test coverage on each subdirectories and merge the coverage profile.
+	echo "mode: count" > profile.cov
+
+	# Standard go tooling behavior is to ignore dirs with leading underscors
+	for dir in $(find . -maxdepth 10 -not -path './.git*' -not -path '*/_*' -not -path './examples/*' -not -path './scripts/*' -not -path './build/*' -not -path './Godeps/*' -type d);
+	do
+		if ls $dir/*.go &> /dev/null; then
+	    		go test --tags=unit -covermode=count -coverprofile=$dir/profile.tmp $dir
+	    		if [ -f $dir/profile.tmp ]
+	    		then
+	        		cat $dir/profile.tmp | tail -n +2 >> profile.cov
+	        		rm $dir/profile.tmp
+	    		fi
+		fi
+	done
+
+	go tool cover -func profile.cov
+
+	# Disabled Coveralls.io for now
+	# To submit the test coverage result to coveralls.io,
+	# use goveralls (https://github.com/mattn/goveralls)
+	# goveralls -coverprofile=profile.cov -service=travis-ci -repotoken t47LG6BQsfLwb9WxB56hXUezvwpED6D11
+	#
+	# If running inside Travis we update coveralls. We don't want his happening on Macs
+	# if [ "$TRAVIS" == "true" ]
+	# then
+	#     n=1
+	#     until [ $n -ge 6 ]
+	#     do
+	#         echo "posting to coveralls attempt $n of 5"
+	#         goveralls -v -coverprofile=profile.cov -service travis.ci -repotoken $COVERALLS_TOKEN && break
+	#         n=$[$n+1]
+	#         sleep 30
+	#     done
+	# fi
+fi

--- a/users/executor.go
+++ b/users/executor.go
@@ -1,0 +1,49 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright 2016 Intel Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package users
+
+import (
+	"os/exec"
+	"strings"
+)
+
+const who = "/usr/bin/who"
+
+// Execution ia an interface and has a single function Execution which returns the number of logged-in users
+type Execution interface {
+	Execute() (uint64, error)
+}
+
+// Executor can execute command `who -u` on local machine
+type Executor struct {
+}
+
+// Execute executes command `who -u` on local machine (which gives a list of logged-in users) and returns the number of logged-in users
+func (e *Executor) Execute() (uint64, error) {
+
+	// execute `who -u`
+	outBytes, err := exec.Command(who, "-u").Output()
+	if err != nil {
+		return 0, err
+	}
+
+	// trim white space, specially the last enter in output
+	out := strings.TrimSpace(string(outBytes))
+
+	// the number of logged users equals the number of lines in output
+	users := len(strings.Split(out, "\n"))
+
+	return uint64(users), nil
+}

--- a/users/users.go
+++ b/users/users.go
@@ -1,0 +1,184 @@
+// +build linux
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright 2016 Intel Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package users
+
+import (
+	"math"
+	"os"
+	"time"
+
+	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
+)
+
+const (
+	// Name of plugin
+	Name = "users"
+	// Version of plugin
+	Version = 1
+	// Type of plugin
+	Type = plugin.CollectorPluginType
+)
+
+var nsPrefix = []string{"intel", "users"}
+
+const (
+	// name of available metrics
+	nLoggedUsers    = "logged"
+	nLoggedUsersMin = "logged_min"
+	nLoggedUsersMax = "logged_max"
+	nLoggedUsersAvg = "logged_avg"
+)
+
+// Users is the main structure, keeps obtained users statistic
+type Users struct {
+	data map[string]interface{}
+	exec Execution
+	avg  average
+}
+
+// average keeps items needed to calculate an average
+type average struct {
+	start time.Time // the start time of average calculation (start collecting)
+	now   time.Time // current time
+}
+
+// CollectMetrics returns values of desired metrics defined in mts
+func (users *Users) CollectMetrics(mts []plugin.PluginMetricType) ([]plugin.PluginMetricType, error) {
+	metrics := make([]plugin.PluginMetricType, len(mts))
+
+	err := users.getUsersStats()
+	if err != nil {
+		return nil, err
+	}
+
+	hostname, _ := os.Hostname()
+	for i, m := range mts {
+		if v, ok := users.data[parseNamespace(m.Namespace())]; ok {
+			metrics[i] = plugin.PluginMetricType{
+				Namespace_: m.Namespace(),
+				Data_:      v,
+				Source_:    hostname,
+				Timestamp_: time.Now(),
+			}
+		}
+	}
+	return metrics, nil
+}
+
+// GetConfigPolicy returns config policy
+func (users *Users) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
+	c := cpolicy.New()
+	return c, nil
+}
+
+// GetMetricTypes returns the metric types exposed by snap-plugin-collector-users
+func (users *Users) GetMetricTypes(_ plugin.PluginConfigType) ([]plugin.PluginMetricType, error) {
+	mts := []plugin.PluginMetricType{}
+
+	for m := range users.data {
+		metric := plugin.PluginMetricType{Namespace_: createNamespace(m)}
+		mts = append(mts, metric)
+	}
+	return mts, nil
+}
+
+// New returns snap-plugin-collector-users instance
+func New() *Users {
+	users := &Users{data: map[string]interface{}{}, avg: average{}, exec: &Executor{}}
+	users.init()
+	return users
+}
+
+// createNamespace returns metric namespace as a slice of strings composed from prefix and metric name
+func createNamespace(name string) []string {
+	return append(nsPrefix, name)
+}
+
+// init initializes users plugin
+func (users *Users) init() {
+	users.data[nLoggedUsers] = uint64(0)
+	users.data[nLoggedUsersMin] = uint64(0)
+	users.data[nLoggedUsersMax] = uint64(0)
+
+	// avg logged users metrics initialize as float64
+	users.data[nLoggedUsersAvg] = float64(0)
+}
+
+// getUsersStats extracts users stats and put them into Users structure
+func (users *Users) getUsersStats() error {
+	lastLogged, err := users.exec.Execute()
+	if err != nil {
+		return err
+	}
+
+	// set logged users value
+	users.data[nLoggedUsers] = lastLogged
+
+	if users.avg.start.Second() == 0 {
+		// first getting users stats, initialize values of metrics
+		users.data[nLoggedUsersMin] = lastLogged
+		users.data[nLoggedUsersMax] = lastLogged
+		users.data[nLoggedUsersAvg] = float64(lastLogged)
+
+		// put average structure items
+		users.avg.start = time.Now()
+		users.avg.now = users.avg.start
+
+		return nil
+	}
+
+	// min logged users
+	if users.data[nLoggedUsersMin].(uint64) > lastLogged {
+		users.data[nLoggedUsersMin] = lastLogged
+	}
+	// max logged users
+	if users.data[nLoggedUsersMax].(uint64) < lastLogged {
+		users.data[nLoggedUsersMax] = lastLogged
+	}
+
+	// avg logged users, calculating an average value
+	last := users.avg.now
+	avg := users.data[nLoggedUsersAvg].(float64)
+	users.avg.now = time.Now()
+	duration := users.avg.now.Sub(users.avg.start).Seconds()
+	interval := users.avg.now.Sub(last).Seconds()
+
+	// formula: `avg = (cnt-1)*avg/cnt+val/cnt`, where cnt is the number of measurements
+	users.data[nLoggedUsersAvg] = roundToPlaces(avg+(float64(lastLogged)-avg)/(round(duration/interval)+1), 2)
+
+	return nil
+}
+
+// parseNamespace performs reverse operation to createNamespace, extracts metric name from namespace
+func parseNamespace(ns []string) (name string) {
+	if len(ns) > len(nsPrefix) {
+		name = ns[len(nsPrefix)]
+	}
+	return name
+}
+
+// round  returns the integral value that is nearest to x
+func round(x float64) float64 {
+	return math.Floor(x + 0.5)
+}
+
+// roundToPlaces returns the value that is nearest to x rounded to the certain decimal places
+func roundToPlaces(x float64, places int) float64 {
+	shift := math.Pow(10, float64(places))
+	return round(x*shift) / shift
+}

--- a/users/users_test.go
+++ b/users/users_test.go
@@ -1,0 +1,204 @@
+// +build linux
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright 2016 Intel Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package users
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/intelsdi-x/snap/control/plugin"
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/mock"
+)
+
+type mcMock struct {
+	mock.Mock
+}
+
+func (mc *mcMock) Execute() (uint64, error) {
+	args := mc.Called()
+
+	return args.Get(0).(uint64), args.Error(1)
+}
+
+var mockMts = []plugin.PluginMetricType{
+	plugin.PluginMetricType{Namespace_: []string{"intel", "users", "logged"}},
+	plugin.PluginMetricType{Namespace_: []string{"intel", "users", "logged_avg"}},
+	plugin.PluginMetricType{Namespace_: []string{"intel", "users", "logged_min"}},
+	plugin.PluginMetricType{Namespace_: []string{"intel", "users", "logged_max"}},
+}
+
+func TestGetConfigPolicy(t *testing.T) {
+	usersPlugin := New()
+
+	Convey("getting config policy", t, func() {
+		So(func() { usersPlugin.GetConfigPolicy() }, ShouldNotPanic)
+		_, err := usersPlugin.GetConfigPolicy()
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestGetMetricTypes(t *testing.T) {
+	var cfg plugin.PluginConfigType
+	usersPlugin := New()
+
+	Convey("getting exposed metric types", t, func() {
+		So(func() { usersPlugin.GetMetricTypes(cfg) }, ShouldNotPanic)
+
+		results, err := usersPlugin.GetMetricTypes(cfg)
+
+		So(err, ShouldBeNil)
+		So(len(results), ShouldEqual, 4) // this plugin exposed 4 metrics (fixed numbers of metrics)
+	})
+}
+
+func TestCollectMetrics(t *testing.T) {
+	mockData := []uint64{6, 10, 2}
+	usersPlugin := New()
+
+	Convey("successful execution of getting users stat", t, func() {
+
+		Convey("the first data collecting", func() {
+			mc := &mcMock{}
+			mc.On("Execute").Return(mockData[0], nil)
+			usersPlugin.exec = mc
+
+			results, err := usersPlugin.CollectMetrics(mockMts)
+
+			So(err, ShouldBeNil)
+			So(len(results), ShouldEqual, len(mockMts))
+
+			for _, metric := range results {
+				// min, max and avg number of logged users are equal
+				So(metric.Data(), ShouldEqual, mockData[0])
+			}
+		})
+
+		Convey("the second data collecting", func() {
+			mc := &mcMock{}
+			mc.On("Execute").Return(mockData[1], nil)
+			usersPlugin.exec = mc
+
+			results, err := usersPlugin.CollectMetrics(mockMts)
+
+			So(err, ShouldBeNil)
+			So(len(results), ShouldEqual, len(mockMts))
+
+			for _, metric := range results {
+				// min, max and avg number of logged users are calculated based on two measurements
+				So(checkValues(metric, mockData[:2]), ShouldEqual, true)
+			}
+		})
+
+		Convey("the third data collecting", func() {
+			mc := &mcMock{}
+			mc.On("Execute").Return(mockData[2], nil)
+			usersPlugin.exec = mc
+
+			results, err := usersPlugin.CollectMetrics(mockMts)
+
+			So(err, ShouldBeNil)
+			So(len(results), ShouldEqual, len(mockMts))
+
+			for _, metric := range results {
+				// min, max and avg number of logged users are calculated based on three measurements
+				So(checkValues(metric, mockData[:3]), ShouldEqual, true)
+			}
+		})
+
+	})
+
+	Convey("failure execution of getting users stat ", t, func() {
+		mc := &mcMock{}
+		mc.On("Execute").Return(uint64(0), errors.New("x"))
+		usersPlugin.exec = mc
+
+		results, err := usersPlugin.CollectMetrics(mockMts)
+
+		So(err, ShouldNotBeNil)
+		So(results, ShouldBeNil)
+	})
+
+}
+
+func checkValues(metric plugin.PluginMetricType, mockData []uint64) bool {
+	result := false
+
+	// get last namespace's item
+	last := len(metric.Namespace()) - 1
+	// approximation error, acceptance boundary is (+/-) 0.5
+	approxErr := 0.5
+	switch metric.Namespace()[last] {
+	case nLoggedUsers:
+		// take the last set mock data
+		if metric.Data() == mockData[len(mockData)-1] {
+			result = true
+		}
+	case nLoggedUsersMin:
+		if metric.Data() == min(mockData) {
+			result = true
+		}
+
+	case nLoggedUsersMax:
+		if metric.Data() == max(mockData) {
+			result = true
+		}
+	case nLoggedUsersAvg:
+		if math.Abs(metric.Data().(float64)-avg(mockData)) <= approxErr {
+			result = true
+		}
+	}
+
+	return result
+}
+
+func min(values []uint64) uint64 {
+	min := values[0]
+	for _, val := range values[1:] {
+		if min > val {
+			min = val
+		}
+	}
+
+	return min
+}
+
+func max(values []uint64) uint64 {
+	max := values[0]
+	for _, val := range values[1:] {
+		if max < val {
+			max = val
+		}
+	}
+
+	return max
+}
+
+func avg(values []uint64) float64 {
+	items := len(values)
+	if items == 0 {
+		return 0
+	}
+
+	sum := values[0]
+	for _, val := range values[1:] {
+		sum += val
+	}
+
+	return float64(sum) / float64(items)
+}


### PR DESCRIPTION
This plugin has the ability to collect the number of logged-in users by the the following metrics:

Metric namespace is `/intel/users/<metric name>/`

| Metric Name | Data Type | Description |
| --- | --- | --- |
| logged | uint64 | A number of users logged-in |
| logged_min | uint64 | A minimum number of logged-in users<sup>(*)</sup> |
| logged_max | uint64 | A maximum number of logged-in users<sup>(*)</sup> |
| logged_avg | float64 | An average number of logged-in users<sup>(*)</sup> |

<sup>(*)</sup> since the task was started   
### Sample output (from "pulsectl task watch"):

![image](https://cloud.githubusercontent.com/assets/11335874/12263317/5fdc8db2-b92e-11e5-9a34-b28116782c21.png)
